### PR TITLE
Fix vector multiplication function

### DIFF
--- a/include/vec.h
+++ b/include/vec.h
@@ -101,16 +101,18 @@ public:
         return *this;
     }
 
-    vec &operator*(const vec &v)
+    float operator*(const vec &v)
     {
         if (m_dim != v.size()) {
             throw new std::invalid_argument("Dimension mismatch");
         }
 
+        float val = 0;
+
         for (size_t i = 0; i < m_dim; i++) {
-            m_buf[i] *= v.m_buf[i];
+            val += m_buf[i] * v.m_buf[i];
         }
-        return *this;
+        return val;
     }
 
     vec &operator*(const float &f)

--- a/tests/TestVec.cpp
+++ b/tests/TestVec.cpp
@@ -68,19 +68,16 @@ TEST(Vec, Mul) {
     picola::vec<3> v1({5, 4, 3});
     picola::vec<3> v2({2, 3, 4});
 
-    v1 = v1 * v2;
+    float val = v1 * v2;
+
+    EXPECT_EQ(val, 34);
+
+    v1 = v1 * 0.5;
 
     std::stringstream ss;
     ss << v1;
 
-    EXPECT_EQ(ss.str(), "10 12 12");
-
-    v1 = v1 * 0.5;
-
-    ss.str("");
-    ss << v1;
-
-    EXPECT_EQ(ss.str(), "5 6 6");
+    EXPECT_EQ(ss.str(), "2.5 2 1.5");
 }
 
 TEST(Vec, Div) {


### PR DESCRIPTION
Multiplying each element of the two vectors is meaningless.
Revise the code to meet dot product definition.